### PR TITLE
Feature/#124 - watchOS 연습 종료 확인 화면

### DIFF
--- a/MC3_Tering/MC3_Tering.xcodeproj/project.pbxproj
+++ b/MC3_Tering/MC3_Tering.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		16BB115A2A734C4500C096D9 /* SwingCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BB11592A734C4500C096D9 /* SwingCompleteView.swift */; };
 		16BB115C2A735ADB00C096D9 /* SelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BB115B2A735ADB00C096D9 /* SelectView.swift */; };
 		B82111502A7413960043CE6D /* WorkoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B821114F2A7413960043CE6D /* WorkoutManager.swift */; };
+		B82111762A75629A0043CE6D /* ElapsedTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82111752A75629A0043CE6D /* ElapsedTimeView.swift */; };
 		B87CEBFA2A70B2B00038BFDB /* TeringClassifier_totalData_window200.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = B87CEBF92A70B2B00038BFDB /* TeringClassifier_totalData_window200.mlmodel */; };
 		B87CEBFC2A70B37E0038BFDB /* TennisClassifierViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87CEBFB2A70B37E0038BFDB /* TennisClassifierViewModel.swift */; };
 		B87CEBFE2A710C600038BFDB /* TeringClassifier_totalData_window100.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = B87CEBFD2A710C600038BFDB /* TeringClassifier_totalData_window100.mlmodel */; };
@@ -188,6 +189,7 @@
 		16BB115B2A735ADB00C096D9 /* SelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectView.swift; sourceTree = "<group>"; };
 		B821114E2A7409080043CE6D /* MC3-Tering-Watch-Watch-App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MC3-Tering-Watch-Watch-App-Info.plist"; sourceTree = SOURCE_ROOT; };
 		B821114F2A7413960043CE6D /* WorkoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutManager.swift; sourceTree = "<group>"; };
+		B82111752A75629A0043CE6D /* ElapsedTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeView.swift; sourceTree = "<group>"; };
 		B87CEBF92A70B2B00038BFDB /* TeringClassifier_totalData_window200.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = TeringClassifier_totalData_window200.mlmodel; sourceTree = "<group>"; };
 		B87CEBFB2A70B37E0038BFDB /* TennisClassifierViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TennisClassifierViewModel.swift; sourceTree = "<group>"; };
 		B87CEBFD2A710C600038BFDB /* TeringClassifier_totalData_window100.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = TeringClassifier_totalData_window100.mlmodel; sourceTree = "<group>"; };
@@ -471,6 +473,7 @@
 			children = (
 				1687E3062A6F74700004D87A /* ColorExtension.swift */,
 				1687E3082A6F74790004D87A /* CircleProgressBar.swift */,
+				B82111752A75629A0043CE6D /* ElapsedTimeView.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -790,6 +793,7 @@
 				16BB115C2A735ADB00C096D9 /* SelectView.swift in Sources */,
 				16BB115A2A734C4500C096D9 /* SwingCompleteView.swift in Sources */,
 				1687E3022A6F732B0004D87A /* CompleteView.swift in Sources */,
+				B82111762A75629A0043CE6D /* ElapsedTimeView.swift in Sources */,
 				1687E3002A6F73230004D87A /* CountingView.swift in Sources */,
 				1687E2E32A6F714D0004D87A /* ViewModelWatch.swift in Sources */,
 				1687E2F22A6F72ED0004D87A /* SwingListView.swift in Sources */,

--- a/MC3_Tering/MC3_Tering.xcodeproj/project.pbxproj
+++ b/MC3_Tering/MC3_Tering.xcodeproj/project.pbxproj
@@ -935,7 +935,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = UULN4L9KLP;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC3-Tering-Info.plist";
@@ -956,7 +956,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.MC3-Tering";
+				PRODUCT_BUNDLE_IDENTIFIER = "kybeen.com.ted.MC3-Tering";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RESOURCES_TARGETED_DEVICE_FAMILY = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -977,7 +977,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = UULN4L9KLP;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC3-Tering-Info.plist";
@@ -998,7 +998,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.MC3-Tering";
+				PRODUCT_BUNDLE_IDENTIFIER = "kybeen.com.ted.MC3-Tering";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RESOURCES_TARGETED_DEVICE_FAMILY = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1019,7 +1019,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MC3_Tering_Watch Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = UULN4L9KLP;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC3-Tering-Watch-Watch-App-Info.plist";
@@ -1028,13 +1028,13 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "To track and record heart rate data for health analysis.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "To track and record heart rate data for health analysis.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.MC3-Tering";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "kybeen.com.ted.MC3-Tering";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.MC3-Tering.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = "kybeen.com.ted.MC3-Tering.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1054,7 +1054,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MC3_Tering_Watch Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = UULN4L9KLP;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC3-Tering-Watch-Watch-App-Info.plist";
@@ -1063,13 +1063,13 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "To track and record heart rate data for health analysis.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "To track and record heart rate data for health analysis.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.MC3-Tering";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "kybeen.com.ted.MC3-Tering";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.MC3-Tering.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = "kybeen.com.ted.MC3-Tering.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;

--- a/MC3_Tering/MC3_Tering_Watch Watch App/Extension/ElapsedTimeView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/Extension/ElapsedTimeView.swift
@@ -1,0 +1,56 @@
+//
+//  ElapsedTimeView.swift
+//  MC3_Tering_Watch Watch App
+//
+//  Created by 김영빈 on 2023/07/30.
+//
+
+import SwiftUI
+
+struct ElapsedTimeView: View {
+    var elapsedTime: TimeInterval = 0
+    var showSubseconds: Bool = true
+    @State private var timeFormatter = ElapsedTimeFormatter()
+
+    var body: some View {
+        Text(NSNumber(value: elapsedTime), formatter: timeFormatter)
+//            .fontWeight(.semibold)
+            .onChange(of: showSubseconds) {
+                timeFormatter.showSubseconds = $0
+            }
+    }
+}
+
+class ElapsedTimeFormatter: Formatter {
+    let componentsFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.zeroFormattingBehavior = .pad
+        return formatter
+    }()
+    var showSubseconds = true
+
+    override func string(for value: Any?) -> String? {
+        guard let time = value as? TimeInterval else {
+            return nil
+        }
+
+        guard let formattedString = componentsFormatter.string(from: time) else {
+            return nil
+        }
+
+        if showSubseconds {
+            let hundredths = Int((time.truncatingRemainder(dividingBy: 1)) * 100)
+            let decimalSeparator = Locale.current.decimalSeparator ?? "."
+            return String(format: "%@%@%0.2d", formattedString, decimalSeparator, hundredths)
+        }
+
+        return formattedString
+    }
+}
+
+struct ElapsedTimeView_Previews: PreviewProvider {
+    static var previews: some View {
+        ElapsedTimeView()
+    }
+}

--- a/MC3_Tering/MC3_Tering_Watch Watch App/Model/SwingInfo.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/Model/SwingInfo.swift
@@ -14,4 +14,5 @@ class SwingInfo: ObservableObject {
     @Published var backhandPerfect: Int?
     @Published var totalBackhandCount: Int?
     @Published var selectedValue: Int? // 목표 스윙 횟수
+    @Published var swingLeft: Int? // 남은 스윙 횟수
 }

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/ReadyView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/ReadyView.swift
@@ -49,6 +49,7 @@ extension ReadyView {
         swingInfo.totalBackhandCount = 0
         swingInfo.forehandPerfect = 0
         swingInfo.backhandPerfect = 0
+        swingInfo.swingLeft = swingInfo.selectedValue // 남은 스윙 횟수 = 선택값 으로 초기화
     }
     
     private func startProgressAnimation() {

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/SwingCountView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/SwingCountView.swift
@@ -132,7 +132,7 @@ struct selectingGoalView: View {
         }
         .onChange(of: valueIndex) { newValue in
             swingInfo.selectedValue = values[newValue]
-            print("selected \(swingInfo.selectedValue)")
+//            print("목표 스윙 횟수 선택 \(swingInfo.selectedValue)")
         }
     }
 

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/SwingCountView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/SwingCountView.swift
@@ -130,6 +130,10 @@ struct selectingGoalView: View {
                 .padding()
             }
         }
+        .onAppear {
+            // 목표 스윙 횟수 선택 안했을 경우 초기값이 있어야 하기 때문에 초기값 세팅
+            swingInfo.selectedValue = values[valueIndex]
+        }
         .onChange(of: valueIndex) { newValue in
             swingInfo.selectedValue = values[newValue]
 //            print("목표 스윙 횟수 선택 \(swingInfo.selectedValue)")

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
@@ -63,35 +63,30 @@ struct QuitView: View {
     @EnvironmentObject var swingInfo: SwingInfo
     
     var body: some View {
-        VStack(alignment: .leading) {
-            Text(swingInfo.swingLeft! > 0 ? "\(swingInfo.swingLeft!)번의 스윙이 남았어요.\n연습을 끝내시겠어요?" : "연습을 끝내시겠어요?")
-                .font(.system(size: 20, weight: .semibold))
-            Spacer()
-  
-            
-            NavigationLink(destination: ResultView(), isActive: $showResultView, label: {
-                Button("종료") {
-//                    getCaloryData()
-//                    getTimeData()
-//                    getDayData()
-                    //                sendDataToPhone()
-    //                tennisClassifierViewModel.stopMotionTracking() // 모션 감지 종료
-                    workoutManager.endWorkout() // 운동 세션 및 모션 감지 종료
-                    showResultView = true
-                    print("====================================================================")
-                    print("showResultView: \(showResultView)")
-                    print("====================================================================")
-                }
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(Color.white)
-                .background(Color.watchColor.lightBlack)
-                .cornerRadius(40)
-            })
-            .buttonStyle(PlainButtonStyle()) // Use PlainButtonStyle to remove button visuals
+        TimelineView(MetricsTimelineSchedule(from: workoutManager.builder?.startDate ?? Date())) { context in
+            VStack(alignment: .leading) {
+                Spacer()
+                // context의 cadence 값에 따라 subseconds를 보여줄지 말지 결정
+                ElapsedTimeView(elapsedTime: workoutManager.builder?.elapsedTime(at: context.date) ?? 0, showSubseconds: context.cadence == .live)
+                    .font(.system(size: 40, weight: .medium))
+                    .foregroundColor(Color.watchColor.lightGreen)
+                Text(swingInfo.swingLeft! > 0 ? "\(swingInfo.swingLeft!)번의 스윙이 남았어요.\n연습을 끝내시겠어요?" : "연습을 끝내시겠어요?")
+                    .font(.system(size: 15))
+                Spacer()
+                
+                NavigationLink(destination: ResultView(), isActive: $showResultView, label: {
+                    Button("종료") {
+                        workoutManager.endWorkout() // 운동 세션 및 모션 감지 종료
+                        showResultView = true
+                    }
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(Color.white)
+                    .background(Color.watchColor.lightBlack)
+                    .cornerRadius(40)
+                })
+                .buttonStyle(PlainButtonStyle()) // Use PlainButtonStyle to remove button visuals
+            }
         }
-//        .onAppear {
-//            healthManager.readCurrentCalories()
-//        }
     }
 }
 
@@ -198,4 +193,39 @@ struct CountingView_Previews: PreviewProvider {
             .environmentObject(WorkoutManager())
             .environmentObject(SwingInfo())
     }
+}
+
+// 활성화된 workout 세션이 있는 앱은 Always On 상태에서 최대 1초에 한 번씩 업데이트가 가능함
+// 따라서 Always On 상태에서는 시간 표시에 subseconds가 들어가지 않도록 해주어야 함
+private struct MetricsTimelineSchedule: TimelineSchedule {
+    var startDate: Date
+//    var isPaused: Bool
+
+//    init(from startDate: Date, isPaused: Bool) {
+//        self.startDate = startDate
+//        self.isPaused = isPaused
+//    }
+    init(from startDate: Date) {
+        self.startDate = startDate
+    }
+
+    func entries(from startDate: Date, mode: TimelineScheduleMode) -> PeriodicTimelineSchedule.Entries {
+        PeriodicTimelineSchedule(
+            from: self.startDate,
+            by: (mode == .lowFrequency ? 1.0 : 1.0 / 30.0)
+        ).entries(
+            from: startDate,
+            mode: mode
+        )
+    }
+//    func entries(from startDate: Date, mode: TimelineScheduleMode) -> AnyIterator<Date> {
+//        var baseSchedule = PeriodicTimelineSchedule(from: self.startDate,
+//                                                    by: (mode == .lowFrequency ? 1.0 : 1.0 / 30.0)) // lowFrequency-1초, normal-1초당30번,
+//            .entries(from: startDate, mode: mode)
+//
+//        return AnyIterator<Date> {
+//            guard !isPaused else { return nil }
+//            return baseSchedule.next()
+//        }
+//    }
 }

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
@@ -53,17 +53,18 @@ struct QuitView: View {
     @EnvironmentObject var workoutManager: WorkoutManager
     @StateObject var tennisClassifierViewModel = TennisClassifierViewModel.shared
     
-    @State var swingLeft: Int = 10
+//    @State var swingLeft: Int = 10
     @State var showResultView = false
     
 //    @ObservedObject var healthManager = HealthKitManager()
 //    @EnvironmentObject var healthInfo: HealthStartInfo // Access the shared instance
 //    @EnvironmentObject var healthResultInfo: HealthResultInfo
     @ObservedObject var model = ViewModelWatch()
+    @EnvironmentObject var swingInfo: SwingInfo
     
     var body: some View {
         VStack(alignment: .leading) {
-            Text("\(swingLeft)번의 스윙이 남았어요.\n연습을 끝내시겠어요?")
+            Text(swingInfo.swingLeft! > 0 ? "\(swingInfo.swingLeft!)번의 스윙이 남았어요.\n연습을 끝내시겠어요?" : "연습을 끝내시겠어요?")
                 .font(.system(size: 20, weight: .semibold))
             Spacer()
   

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/SwingResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/SwingResultView.swift
@@ -70,6 +70,7 @@ extension SwingResultView {
     
     private func calculateSwings() {
         swingInfo.totalSwingCount! += 1
+        swingInfo.swingLeft! -= 1
         
         if tennisClassifierViewModel.classLabel == "Forehand" {
             if tennisClassifierViewModel.resultLabel == "PERFECT" {
@@ -88,6 +89,7 @@ extension SwingResultView {
         print("totalBackhandCount -> \(swingInfo.totalBackhandCount)")
         print("ForehandPerfect -> \(swingInfo.forehandPerfect)")
         print("BackhandPerfect -> \(swingInfo.backhandPerfect)")
+        print("남은 스윙 -> \(swingInfo.swingLeft)/\(swingInfo.selectedValue)")
 
     }
     


### PR DESCRIPTION
## 🎾 PR 요약
- watchOS 스윙 연습 종료 확인 화면 관련 작업

🌱 작업한 브랜치
- feature/#124

## ✏️ 작업한 내용
-  남은 스윙 횟수에 따른 분기 처리
-  실시간 시간 표시 뷰 추가
-  백그라운드 모드에서 subseconds 가려지도록 설정

## 📌 참고 사항
- 목표 스윙 횟수의 기본값이 없기 때문에 SwingCountView에서 picker 동작 없이 넘어가면 nil값으로 오류나는 문제 있었음
  - onAppear에서 기본값으로 10을 할당해서 해결

## 🎬 스크린샷
<img width="459" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/15eedf41-5400-4620-aef7-c11482be4930">


## 📮 관련 이슈
- Resolved: #

