### PR TITLE
Feature/#125 - watchOS 운동 데이터 iOS로 전송

### DIFF
--- a/MC3_Tering/MC3_Tering_Watch Watch App/MC3_Tering_WatchApp.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/MC3_Tering_WatchApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct MC3_Tering_Watch_Watch_AppApp: App {
     @StateObject var swingListWrapper = SwingListWrapper(swingList: SwingList(name: "", guideButton: "", gifImage: ""))
 //    @StateObject var healthStartInfo = HealthStartInfo() // Create an instance of HealthStartInfo
-//    @StateObject var healthResultInfo = HealthResultInfo()
+    @StateObject var healthResultInfo = HealthResultInfo()
     @StateObject var swingInfo = SwingInfo()
     @StateObject var workoutManager = WorkoutManager()
     
@@ -23,7 +23,7 @@ struct MC3_Tering_Watch_Watch_AppApp: App {
             SwingCountView()
                 .environmentObject(swingListWrapper)
 //                .environmentObject(healthStartInfo)
-//                .environmentObject(healthResultInfo)
+                .environmentObject(healthResultInfo)
                 .environmentObject(swingInfo)
                 .environmentObject(workoutManager)
             //이거 왜 이러는거임?

--- a/MC3_Tering/MC3_Tering_Watch Watch App/Model/HealthResultInfo.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/Model/HealthResultInfo.swift
@@ -5,10 +5,11 @@
 //  Created by KimTaeHyung on 2023/07/25.
 //
 
-//import Foundation
-//
-//class HealthResultInfo: ObservableObject {
-//    @Published var burningCal: Int?
-//    @Published var workOutTime: Int?
-//    @Published var workOutDate: Date?
-//}
+import Foundation
+
+class HealthResultInfo: ObservableObject {
+    @Published var burningCal: Int?
+    @Published var workOutTime: Int?
+    @Published var workOutDate: Date?
+}
+

--- a/MC3_Tering/MC3_Tering_Watch Watch App/Model/HealthResultInfo.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/Model/HealthResultInfo.swift
@@ -8,8 +8,9 @@
 import Foundation
 
 class HealthResultInfo: ObservableObject {
-    @Published var burningCal: Int?
-    @Published var workOutTime: Int?
-    @Published var workOutDate: Date?
+    @Published var averageHeartRate: Int? // 평균 심박수
+    @Published var burningCal: Int? // 소모 칼로리
+    @Published var workOutTime: Int? // 운동 시간
+    @Published var workOutDate: Date? // 운동일
 }
 

--- a/MC3_Tering/MC3_Tering_Watch Watch App/Model/SwingInfo.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/Model/SwingInfo.swift
@@ -16,3 +16,4 @@ class SwingInfo: ObservableObject {
     @Published var selectedValue: Int? // 목표 스윙 횟수
     @Published var swingLeft: Int? // 남은 스윙 횟수
 }
+

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
@@ -332,7 +332,11 @@ extension HealthKitView {
             "totalForehandCount" : self.swingInfo.totalForehandCount,
             "backhandPerfect" : self.swingInfo.backhandPerfect,
             "totalBackhandCount" : self.swingInfo.totalBackhandCount,
-            "selectedValue" : self.swingInfo.selectedValue
+            "selectedValue" : self.swingInfo.selectedValue,
+            "averageHeartRate" : healthResultInfo.averageHeartRate, // 평균 심박수
+            "burningCal" : healthResultInfo.burningCal, // 소모 칼로리
+            "workOutTime" : healthResultInfo.workOutTime, // 운동 시간
+            "workOutDate" : healthResultInfo.workOutDate // 운동일
         ])
     }
 }

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
@@ -222,7 +222,7 @@ struct HealthKitView: View {
     
 //    @ObservedObject var healthManager = HealthKitManager()
 //    @EnvironmentObject var healthInfo: HealthStartInfo // Access the shared instance
-//    @EnvironmentObject var healthResultInfo: HealthResultInfo
+    @EnvironmentObject var healthResultInfo: HealthResultInfo
     @ObservedObject var model = ViewModelWatch()
     @EnvironmentObject var swingInfo: SwingInfo
     
@@ -270,6 +270,11 @@ struct HealthKitView: View {
                 .cornerRadius(20)
             }
             .onAppear {
+                print("===============================결과 확인===================================")
+                print("저장된 소모 칼로리 : \(healthResultInfo.burningCal)")
+                print("저장된 운동 시간 : \(healthResultInfo.workOutTime)")
+                print("저장된 운동일 : \(healthResultInfo.workOutDate)")
+                print("======================================================================")
     //            healthManager.readCurrentCalories()
                 sendDataToPhone()
                 sendSwingDataToPhone()
@@ -283,6 +288,7 @@ struct ResultView_Previews: PreviewProvider {
     static var previews: some View {
         HealthKitView()
             .environmentObject(WorkoutManager())
+            .environmentObject(HealthResultInfo())
 //            .environmentObject(SwingListWrapper(swingList: SwingList(name: "포핸드", guideButton: "questionmark.circle", gifImage: "square")))
     }
 }
@@ -319,12 +325,14 @@ extension HealthKitView {
     }
     
     private func sendSwingDataToPhone() {
-        self.model.session.transferUserInfo(["totalSwingCount" : self.swingInfo.totalSwingCount])
-        self.model.session.transferUserInfo(["forehandPerfect" : self.swingInfo.forehandPerfect])
-        self.model.session.transferUserInfo(["totalForehandCount" : self.swingInfo.totalForehandCount])
-        self.model.session.transferUserInfo(["backhandPerfect" : self.swingInfo.backhandPerfect])
-        self.model.session.transferUserInfo(["totalBackhandCount" : self.swingInfo.totalBackhandCount])
-        self.model.session.transferUserInfo(["selectedValue" : self.swingInfo.selectedValue])
+        self.model.session.transferUserInfo([
+            "totalSwingCount" : self.swingInfo.totalSwingCount,
+            "forehandPerfect" : self.swingInfo.forehandPerfect,
+            "totalForehandCount" : self.swingInfo.totalForehandCount,
+            "backhandPerfect" : self.swingInfo.backhandPerfect,
+            "totalBackhandCount" : self.swingInfo.totalBackhandCount,
+            "selectedValue" : self.swingInfo.selectedValue
+        ])
     }
 }
 

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
@@ -271,6 +271,7 @@ struct HealthKitView: View {
             }
             .onAppear {
                 print("===============================결과 확인===================================")
+                print("저장된 평균 심박수 : \(healthResultInfo.averageHeartRate)")
                 print("저장된 소모 칼로리 : \(healthResultInfo.burningCal)")
                 print("저장된 운동 시간 : \(healthResultInfo.workOutTime)")
                 print("저장된 운동일 : \(healthResultInfo.workOutDate)")

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/ReadyView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/ReadyView.swift
@@ -17,6 +17,7 @@ struct ReadyView: View {
 
 //    @Binding var selectedValue: Int
     @EnvironmentObject var swingInfo: SwingInfo
+    @EnvironmentObject var healthResultInfo: HealthResultInfo
 
     var body: some View {
         VStack {
@@ -50,6 +51,7 @@ extension ReadyView {
         swingInfo.forehandPerfect = 0
         swingInfo.backhandPerfect = 0
         swingInfo.swingLeft = swingInfo.selectedValue // 남은 스윙 횟수 = 선택값 으로 초기화
+        healthResultInfo.workOutDate = Date() // 운동 시작일 저장
     }
     
     private func startProgressAnimation() {

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/ReadyView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/StartView/ReadyView.swift
@@ -18,7 +18,7 @@ struct ReadyView: View {
 //    @Binding var selectedValue: Int
     @EnvironmentObject var swingInfo: SwingInfo
     @EnvironmentObject var healthResultInfo: HealthResultInfo
-
+    
     var body: some View {
         VStack {
             TimeCircleProgressBar(progress: self.$progressValue, count: self.$countValue, fontSize: self.$fontSize)

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
@@ -93,7 +93,6 @@ struct QuitView: View {
                         
                         // Workout 데이터 HealthResultInfo 모델에 저장
                         healthResultInfo.workOutTime = Int(workoutManager.builder?.elapsedTime(at: context.date) ?? 0) // 운동 시간
-                        healthResultInfo.workOutDate = Date() //TODO: 운동 날짜 -> 운동 시작한 날 기준으로 값 받도록 수정하기
                         healthResultInfo.burningCal = Int(workoutManager.activeEnergy.rounded()) // 소모 칼로리
                         healthResultInfo.averageHeartRate = Int(workoutManager.averageHeartRate.rounded()) // 평균 심박수
                         

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
@@ -92,7 +92,7 @@ struct QuitView: View {
 //                        print("======================================================================")
                         
                         // Workout 데이터 HealthResultInfo 모델에 저장
-                        healthResultInfo.workOutTime = Int(workoutManager.builder?.elapsedTime(at: context.date) ?? 0) // 운동 시간
+                        healthResultInfo.workOutTime = Int(((workoutManager.builder?.elapsedTime(at: context.date) ?? 0) / 60).rounded()) // 운동 시간(초 -> 분 단위로 변환)
                         healthResultInfo.burningCal = Int(workoutManager.activeEnergy.rounded()) // 소모 칼로리
                         healthResultInfo.averageHeartRate = Int(workoutManager.averageHeartRate.rounded()) // 평균 심박수
                         

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
@@ -85,23 +85,20 @@ struct QuitView: View {
                 
                 NavigationLink(destination: ResultView(), isActive: $showResultView, label: {
                     Button("종료") {
+//                        print("===============================운동 종료===================================")
+//                        print("운동시간---> \(workoutManager.builder?.elapsedTime(at: context.date) ?? 0)")
+//                        print("평균 심박수---> \(workoutManager.averageHeartRate)")
+//                        print("칼로리---> \(workoutManager.activeEnergy)")
+//                        print("======================================================================")
+                        
                         // Workout 데이터 HealthResultInfo 모델에 저장
-                        healthResultInfo.workOutTime = Int(workoutManager.builder?.elapsedTime(at: context.date) ?? 0)
-                        // 운동 시간
+                        healthResultInfo.workOutTime = Int(workoutManager.builder?.elapsedTime(at: context.date) ?? 0) // 운동 시간
                         healthResultInfo.workOutDate = Date() //TODO: 운동 날짜 -> 운동 시작한 날 기준으로 값 받도록 수정하기
                         healthResultInfo.burningCal = Int(workoutManager.activeEnergy.rounded()) // 소모 칼로리
+                        healthResultInfo.averageHeartRate = Int(workoutManager.averageHeartRate.rounded()) // 평균 심박수
                         
                         workoutManager.endWorkout() // 운동 세션 및 모션 감지 종료
                         showResultView = true
-                        
-                        print("===============================운동 종료===================================")
-                        print("운동시간---> \(workoutManager.builder?.elapsedTime(at: context.date) ?? 0)")
-                        print("Formatter 적용한 운동시간---> \(workoutTimeFormatter.string(from: workoutManager.builder?.elapsedTime(at: context.date) ?? 0))")
-                        print("심박수---> \(workoutManager.averageHeartRate)")
-                        print("Formatter 적용한 심박수---> \(workoutManager.averageHeartRate.formatted(.number.precision(.fractionLength(0))))")
-                        print("칼로리---> \(workoutManager.activeEnergy)")
-                        print("Formatter 적용한 칼로리---> \(Measurement(value: workoutManager.activeEnergy, unit: UnitEnergy.kilocalories).formatted(.measurement(width: .abbreviated, usage: .workout, numberFormatStyle: .number.precision(.fractionLength(0)))))")
-                        print("======================================================================")
                     }
                     .font(.system(size: 20, weight: .semibold))
                     .foregroundColor(Color.white)


### PR DESCRIPTION
## 🎾 PR 요약
- watchOS에서 만들어진 Workout 관련 데이터를 iOS로 전송하도록 해줌

🌱 작업한 브랜치
- feature/#125

## ✏️ 작업한 내용
- 운동 종료 시 HealthResultInfo 모델에 Workout 데이터 저장
- 운동 시간 분 단위로 받도록 해줌
- 운동일 운동 시작 시점 기준으로 저장
- watchOS --> iOS 데이터 전송 메서드에 Workout 데이터 추가

## 📌 참고 사항
- 운동일 Timezone 현재 위치 기준으로 받아오는지 확인 필요

## 🎬 스크린샷


## 📮 관련 이슈
- Resolved: #

