### PR TITLE
[Add] #129 - 기록 탭뷰 하단 차트 추가 중

### DIFF
--- a/MC3_Tering/MC3_Tering/View/MainView/ChartView/CompareChartView.swift
+++ b/MC3_Tering/MC3_Tering/View/MainView/ChartView/CompareChartView.swift
@@ -9,6 +9,19 @@ import SwiftUI
 
 //MARK: - 기록 탭뷰 하단 비교 차트
 struct CompareChartView: View {
+    var periodLabel1: String // 기간 라벨1
+    var periodLabel2: String // 기간 라벨2
+    var swingLabel: String // 포핸드 / 백핸드
+    var raisedCount: Int // 몇 회 늘었는지(줄었는지)
+    var raiseState: Bool // '늘었습니다' '줄었습니다' 정하는 변수
+    var raiseLabel: String {
+        if raiseState {
+            return "늘었습니다"
+        } else {
+            return "줄었습니다"
+        }
+    }
+    
     var body: some View {
         ZStack {
             Rectangle()
@@ -18,7 +31,7 @@ struct CompareChartView: View {
                 .cornerRadius(13)
                 .padding(.top, 14)
             VStack(spacing: 0) {
-                Text("지난 7일간 총 Perfect Swing 수는 평균 120회입니다.")
+                Text("\(periodLabel1) \(swingLabel) Perfect Swing 수가\n\(periodLabel2)보다 \(raisedCount)회 \(raiseLabel).")
                     .font(.custom("Inter-SemiBold", size: 16))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(Color.theme.teWhite)
@@ -27,49 +40,102 @@ struct CompareChartView: View {
                     .frame(height: 0.5)
                     .padding(.top, 10)
                     .foregroundColor(Color.theme.teWhite)
-    
-//                horizontalBarGraphContainer(todayPerfect, yesterdayPerfect, leftColor: Color.theme.teGreen, rightColor: Color.theme.teSkyBlue, false, true)
-//                horizontalBarGraphContainer(yesterdayPerfect, todayPerfect, false, false)
+                
+                SummaryCompareBox(selfValue: 430, compareValue: 180, leftColor: Color("TennisBlack"), rightColor: Color("TennisSkyBlue"), startMonth: 7, startDay: 4, endMonth: 7, endDay: 11)
+                SummaryCompareBox(selfValue: 180, compareValue: 430, leftColor: Color("TennisBlack"), rightColor: Color("TennisWhite"), startMonth: 6, startDay: 28, endMonth: 7, endDay: 4)
             }
             .frame(alignment: .leading)
             .padding(EdgeInsets(top: 10, leading: 15, bottom: 10, trailing: 15))
         }
+        .frame(alignment: .leading)
     }
 }
 
-struct CompareChartView_Previews: PreviewProvider {
-    static var previews: some View {
-        CompareChartView()
-    }
-}
-
-//private func summaryCountBox(_ firstLineString: String, _ compareString: String, _ isBackhand: Bool) -> some View {
-//    let todayPerfect = Int(workoutDataModel.todayChartDatum[isBackhand ? 3 : 0])
-//    let yesterdayPerfect = Int(workoutDataModel.todayChartDatum[isBackhand ? 4 : 1])
-//    let difference = Int(workoutDataModel.todayChartDatum[isBackhand ? 5 : 2])
-//
-//    return ZStack {
-//        Rectangle()
-//            .foregroundColor(.clear)
-//            .frame(maxWidth: .infinity, minHeight: 254)
-//            .background(Color.theme.teDarkGray)
-//            .cornerRadius(13)
-//            .padding(.top, 14)
-//        VStack(spacing: 0) {
-//            Text("\(firstLineString) \(compareString)\n\(abs(difference))회 \(difference > 0 ? "늘었습니다" : "줄었습니다").")
-//                .font(.custom("Inter-SemiBold", size: 16))
-//                .frame(maxWidth: .infinity, alignment: .leading)
-//                .foregroundColor(Color.theme.teWhite)
-//
-//            Rectangle()
-//                .frame(height: 0.5)
-//                .padding(.top, 10)
-//                .foregroundColor(Color.theme.teWhite)
-//
-//            horizontalBarGraphContainer(todayPerfect, yesterdayPerfect, leftColor: Color.theme.teGreen, rightColor: Color.theme.teSkyBlue, false, true)
-//            horizontalBarGraphContainer(yesterdayPerfect, todayPerfect, false, false)
-//        }
-//        .frame(alignment: .leading)
-//        .padding(EdgeInsets(top: 10, leading: 15, bottom: 10, trailing: 15))
+//struct CompareChartView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CompareChartView()
 //    }
 //}
+
+//MARK: - 움직이는 막대 뷰
+struct SummaryCompareBox: View {
+    let screenSize = UIScreen.main.bounds.width
+    
+    var selfValue: Int // 기준값
+    var compareValue: Int // 비교값
+    var leftColor: Color = Color("TennisWhite") // 그라데이션 왼쪽 색
+    var rightColor: Color = Color("TennisWhite") // 그라데이션 오른쪽 색
+    
+    var startMonth: Int
+    var startDay: Int
+    var endMonth: Int
+    var endDay: Int
+    
+    @State var isAnimationEnabled = false
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 2) {
+                Text("\(selfValue)")
+                    .font(.custom("Inter-SemiBold", size: 30))
+                    .foregroundColor(Color("TennisWhite"))
+                Text("회")
+                    .font(.custom("Inter-SemiBold", size: 24))
+                    .foregroundColor(Color("TennisWhite"))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            VStack {
+                ZStack {
+                    Rectangle()
+                        .foregroundColor(.clear)
+                        .frame(maxWidth: sizeCalculate(CGFloat(selfValue), CGFloat(compareValue)), maxHeight: 23)
+                        .background(
+                            LinearGradient(
+                                stops: [
+                                    Gradient.Stop(color: rightColor, location: 0.00),
+                                    Gradient.Stop(color: leftColor, location: 1.00)
+                                ],
+                                startPoint: UnitPoint(x: 1, y: 0.52),
+                                endPoint: UnitPoint(x: -0.06, y: 0.52)
+                            )
+                        )
+                        .cornerRadius(5)
+                        .overlay(
+                            Text("\(startMonth)/\(startDay)~\(endMonth)/\(endDay)")
+                                .foregroundColor(.black)
+                                .font(.custom("Inter-SemiBold", size: 14))
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                                .padding(.trailing, 16)
+                                
+                        )
+                        .scaleEffect(x: isAnimationEnabled ? 1 : 0, y: 1, anchor: .leading)
+                        .animation(.easeOut(duration: isAnimationEnabled ? 2 : 0), value: isAnimationEnabled)
+                        .padding(.top, 10)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .onAppear {
+                    // 애니메이션 활성화
+                    if isAnimationEnabled {
+                        isAnimationEnabled = false
+                    } else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            isAnimationEnabled = true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension SummaryCompareBox {
+    func sizeCalculate(_ A: CGFloat, _ B: CGFloat) -> CGFloat {
+        if A == 0 || B == 0 {
+            return CGFloat(45)
+        }
+        print("막대그래프 길이 : ",CGFloat(A / B * screenSize) < 60 ? 60 : CGFloat(A / B * screenSize))
+        return CGFloat(A / B * screenSize) < 45 ? 45 : CGFloat(A / B * screenSize)
+        
+    }
+}

--- a/MC3_Tering/MC3_Tering/View/MainView/ChartView/MonthChartView.swift
+++ b/MC3_Tering/MC3_Tering/View/MainView/ChartView/MonthChartView.swift
@@ -122,7 +122,7 @@ struct MonthChartView: View {
                         y: .value("Count", element.count),
                         stacking: .unstacked // 바 차트 겹쳐서 보기 위한 파라미터
                     )
-                    .cornerRadius(5)
+//                    .cornerRadius(5)
                     .foregroundStyle(by: .value("Swing Type", eachType.swingDataType))
                 }
             }

--- a/MC3_Tering/MC3_Tering/View/MainView/ChartView/PerfectSummaryChartView.swift
+++ b/MC3_Tering/MC3_Tering/View/MainView/ChartView/PerfectSummaryChartView.swift
@@ -10,68 +10,61 @@ import SwiftUI
 
 //MARK: - 기록 탭뷰 하단 퍼펙트 요약 차트
 struct PerfectSummaryChartView: View {
-    var titleLabel: String
     var descriptionLabel: String
     var perfectSwingAverage: Int
     
     var body: some View {
-        VStack(spacing: 0) {
-            Text(titleLabel)
-                .font(.custom("Inter-Bold", size: 24))
-                .frame(maxWidth: .infinity, alignment: .leading)
-            ZStack {
+        ZStack {
+            Rectangle()
+                .foregroundColor(.clear)
+                .frame(maxWidth: .infinity, minHeight: 277)
+                .background(Color.theme.teDarkGray)
+                .cornerRadius(13)
+                .padding(.top, 14)
+            VStack(spacing: 0) {
+                Text("지난 \(descriptionLabel)간 총 Perfect Swing 수는\n평균 \(perfectSwingAverage)회 입니다.")
+                    .font(.custom("Inter-SemiBold", size: 16))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundColor(Color.theme.teWhite)
+
                 Rectangle()
-                    .foregroundColor(.clear)
-                    .frame(maxWidth: .infinity, minHeight: 277)
-                    .background(Color.theme.teDarkGray)
-                    .cornerRadius(13)
-                    .padding(.top, 14)
-                VStack(spacing: 0) {
-                    Text("지난 \(descriptionLabel)간 총 Perfect Swing 수는\n평균 \(perfectSwingAverage)회 입니다.")
-                        .font(.custom("Inter-SemiBold", size: 16))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .foregroundColor(Color.theme.teWhite)
+                    .frame(height: 0.5)
+                    .padding(.top, 10)
+                    .foregroundColor(Color.theme.teWhite)
 
-                    Rectangle()
-                        .frame(height: 0.5)
-                        .padding(.top, 10)
-                        .foregroundColor(Color.theme.teWhite)
-
-                    Chart {
-                        ForEach(weekPerfectSwingData) { element in
-                            BarMark(
-                                x:.value("Week Day", element.weekday),
-                                y: .value("Count", element.count)
-                            )
-                            .cornerRadius(5)
-                            .foregroundStyle(.linearGradient(colors: [Color("TennisSkyBlue"), Color.theme.teDarkGray], startPoint: .init(x: 0.5, y: 0), endPoint: .init(x: 0.5, y: 1)))
-                        }
-                        RuleMark(
-                            y: .value("Perfect Average", perfectSwingAverage)
+                Chart {
+                    ForEach(weekPerfectSwingData) { element in
+                        BarMark(
+                            x:.value("Week Day", element.weekday),
+                            y: .value("Count", element.count)
                         )
-                        .foregroundStyle(Color("TennisGreen"))
-                        .lineStyle(StrokeStyle(dash: [2.5]))
-                        .annotation(position: .leading, alignment: .leading) {
-                            HStack(alignment: .bottom, spacing: 0) {
-                                Text("\(perfectSwingAverage)")
-                                    .font(.custom("Inter-SemiBold", size: 32))
-                                Text("회")
-                                    .font(.custom("Inter-SemiBold", size: 12))
-                            }
-                            .foregroundColor(Color("TennisGreen"))
-                        }
+                        .cornerRadius(5)
+                        .foregroundStyle(.linearGradient(colors: [Color("TennisSkyBlue"), Color.theme.teDarkGray], startPoint: .init(x: 0.5, y: 0), endPoint: .init(x: 0.5, y: 1)))
                     }
-                    .chartXAxis(.hidden)
-                    .chartYAxis(.hidden)
-                    .frame(height: 160)
-                    .padding(.top, 30)
-                    .padding(.leading, 70)
+                    RuleMark(
+                        y: .value("Perfect Average", perfectSwingAverage)
+                    )
+                    .foregroundStyle(Color("TennisGreen"))
+                    .lineStyle(StrokeStyle(lineWidth: 2.5, dash: [2]))
+                    .annotation(position: .leading, alignment: .leading) {
+                        HStack(alignment: .lastTextBaseline, spacing: 0) {
+                            Text("\(perfectSwingAverage)")
+                                .font(.custom("Inter-SemiBold", size: 32))
+                            Text("회")
+                                .font(.custom("Inter-SemiBold", size: 12))
+                        }
+                        .foregroundColor(Color("TennisGreen"))
+                    }
                 }
-                .padding(EdgeInsets(top: 10, leading: 15, bottom: 0, trailing: 15))
+                .chartForegroundStyleScale(["퍼펙트 스윙 쇳수": .linearGradient(colors: [Color("TennisSkyBlue"), Color("TennisBlack")], startPoint: .init(x: 0.5, y: 0.0), endPoint: .init(x: 0.5, y: 0.8))])
+                .chartXAxis(.hidden)
+                .chartYAxis(.hidden)
+                .frame(width: 220, height: 160)
+                .padding(.top, 30)
+                .padding(.leading, 70)
             }
+            .padding(EdgeInsets(top: 10, leading: 15, bottom: 0, trailing: 15))
         }
-        .padding(.leading, 17)
-        .padding(.trailing, 17)
     }
 }
 

--- a/MC3_Tering/MC3_Tering/View/MainView/ChartView/WeekChartview.swift
+++ b/MC3_Tering/MC3_Tering/View/MainView/ChartView/WeekChartview.swift
@@ -83,13 +83,13 @@ struct WeekChartview: View {
                     y:.value("Total Average", weekTotalSwingAverage)
                 )
                 .foregroundStyle(Color("TennisGreen"))
-                .lineStyle(StrokeStyle(dash: [2]))
+                .lineStyle(StrokeStyle(lineWidth: 2.5, dash: [2]))
                 
                 RuleMark(
                     y: .value("Perfect Average", weekPerfectSwingAverage)
                 )
                 .foregroundStyle(Color("TennisSkyBlue"))
-                .lineStyle(StrokeStyle(dash: [2]))
+                .lineStyle(StrokeStyle(lineWidth: 2.5, dash: [2]))
             }
             .chartForegroundStyleScale([
                 "전체 스윙 횟수": .linearGradient(colors: [Color("TennisGreen"), Color("TennisBlack")], startPoint: .init(x: 0.5, y: 0.0), endPoint: .init(x: 0.5, y: 0.8)),
@@ -100,9 +100,17 @@ struct WeekChartview: View {
             .padding()
             .frame(height: UIScreen.main.bounds.height*0.5)
             
-            PerfectSummaryChartView(titleLabel: "주간 활동", descriptionLabel: "7일", perfectSwingAverage: Int(weekPerfectSwingAverage))
-            
-            WorkoutSummaryChartView(timeAverage: 4, caloryAverage: 200) //TODO: 인자값 바꾸기
+            VStack(spacing: 0) {
+                Text("주간 활동")
+                    .font(.custom("Inter-Bold", size: 24))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                PerfectSummaryChartView(descriptionLabel: "7일", perfectSwingAverage: Int(weekPerfectSwingAverage))
+                CompareChartView(periodLabel1: "지난 7일간", periodLabel2: "그 전주", swingLabel: "포핸드", raisedCount: 20, raiseState: true)
+                CompareChartView(periodLabel1: "지난 7일간", periodLabel2: "그 전주", swingLabel: "백핸드", raisedCount: 20, raiseState: true)
+                WorkoutSummaryChartView(timeAverage: 76, caloryAverage: 200) //TODO: 인자값 바꾸기
+            }
+            .padding(.leading, 17)
+            .padding(.trailing, 17)
         }
     }
 }

--- a/MC3_Tering/MC3_Tering/View/MainView/ChartView/WorkoutSummaryChartView.swift
+++ b/MC3_Tering/MC3_Tering/View/MainView/ChartView/WorkoutSummaryChartView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 
 //MARK: - 기록 탭뷰 하단 운동시간,칼로리 요약 차트
 struct WorkoutSummaryChartView: View {
-    var descriptionLabel: String = "7일간"
-    var timeAverage: Double
-    var caloryAverage: Double
+    var descriptionLabel: String = "7일"
+    var timeAverage: Int
+    var caloryAverage: Int
     
     var body: some View {
         ZStack {
@@ -23,7 +23,7 @@ struct WorkoutSummaryChartView: View {
                 .cornerRadius(13)
                 .padding(.top, 14)
             VStack(spacing: 0) {
-                Text("지난 \(descriptionLabel)간 운동시간과 소모한 칼로리는\n각 평균 \(String(format: "%.2f", timeAverage))시간, \(String(format: "%.2f", caloryAverage))칼로리 입니다.")
+                Text("지난 \(descriptionLabel)간 운동시간과 소모한 칼로리는\n각 평균 \(timeAverage)분, \(caloryAverage)칼로리 입니다.")
                     .font(.custom("Inter-SemiBold", size: 16))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(Color.theme.teWhite)
@@ -49,47 +49,45 @@ struct WorkoutSummaryChartView: View {
                     RuleMark(
                         y:.value("Workout Time Average", timeAverage)
                     )
-                    .foregroundStyle(Color("TennisGreen"))
-                    .lineStyle(StrokeStyle(dash: [2.5]))
+                    .foregroundStyle(Color("TennisWhite"))
+                    .lineStyle(StrokeStyle(lineWidth: 2.5, dash: [2]))
                     .annotation(position: .leading, alignment: .leading) {
-                        HStack(alignment: .bottom, spacing: 0) {
-                            Text("\(String(format: "%.2f", timeAverage))")
+                        HStack(alignment: .lastTextBaseline, spacing: 0) {
+                            Text("\(timeAverage)")
                                 .font(.custom("Inter-SemiBold", size: 32))
-                            Text("시간")
+                            Text("분")
                                 .font(.custom("Inter-SemiBold", size: 12))
                         }
-                        .foregroundColor(Color("TennisSkyBlue"))
+                        .foregroundColor(Color("TennisWhite"))
                     }
                     
                     RuleMark(
                         y: .value("Burned Calory Average", caloryAverage)
                     )
                     .foregroundStyle(Color("TennisSkyBlue"))
-                    .lineStyle(StrokeStyle(dash: [2.5]))
+                    .lineStyle(StrokeStyle(lineWidth: 2.5, dash: [2]))
                     .annotation(position: .leading, alignment: .leading) {
-                        HStack(alignment: .bottom, spacing: 0) {
-                            Text("\(String(format: "%.2f", caloryAverage))")
+                        HStack(alignment: .lastTextBaseline, spacing: 0) {
+                            Text("\(caloryAverage)")
                                 .font(.custom("Inter-SemiBold", size: 32))
                             Text("kcal")
                                 .font(.custom("Inter-SemiBold", size: 12))
                         }
-                        .foregroundColor(Color("TennisWhite"))
+                        .foregroundColor(Color("TennisSkyBlue"))
                     }
                 }
                 .chartForegroundStyleScale([
-                    "전체 스윙 횟수": .linearGradient(colors: [Color("TennisGreen"), Color("TennisBlack")], startPoint: .init(x: 0.5, y: 0.0), endPoint: .init(x: 0.5, y: 0.8)),
-                    "퍼펙트 스윙 횟수": .linearGradient(colors: [Color("TennisSkyBlue"), Color("TennisBlack")], startPoint: .init(x: 0.5, y: 0), endPoint: .init(x: 0.5, y: 0.9))
+                    "전체 스윙 횟수": .linearGradient(colors: [Color("TennisSkyBlue"), Color("TennisBlack")], startPoint: .init(x: 0.5, y: 0.0), endPoint: .init(x: 0.5, y: 0.8)),
+                    "퍼펙트 스윙 횟수": .linearGradient(colors: [Color("TennisWhite"), Color("TennisBlack")], startPoint: .init(x: 0.5, y: 0.0), endPoint: .init(x: 0.5, y: 1.2))
                 ])
                 .chartXAxis(.hidden)
                 .chartYAxis(.hidden)
-                .frame(height: 160)
+                .frame(width: 220, height: 160)
                 .padding(.top, 30)
                 .padding(.leading, 70)
             }
             .padding(EdgeInsets(top: 10, leading: 15, bottom: 0, trailing: 15))
         }
-        .padding(.leading, 17)
-        .padding(.trailing, 17)
     }
 }
 


### PR DESCRIPTION
## 🎾 PR 요약
- 기록 탭뷰 하단 차트 추가 중

🌱 작업한 브랜치
- feature/#129

## ✏️ 작업한 내용
- 1주 기준 하단 차트들 모두 추가함

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 데이터 모델 연동이랑 기간 별 다르게 표시 필요함
- 더미 데이터만 넣어놓은 상태

## 🎬 스크린샷
<img width="252" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/e9b78f24-bab5-4a5c-8a05-1f8f061a1b0a">


## 📮 관련 이슈
- Resolved: #

