### PR TITLE
[Fix] 10초 이상 운동 시 ResultView 운동 결과 탭 전환 문제 해결 #152

### DIFF
--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
@@ -15,6 +15,7 @@ import HealthKit
 struct ResultView: View {
     @State private var selectedTab = 1
     @ObservedObject var workoutDataModel: WorkOutDataModel
+    @EnvironmentObject var workoutManager: WorkoutManager
     
     init(workoutDataModel: WorkOutDataModel) {
         self.workoutDataModel = workoutDataModel
@@ -52,6 +53,10 @@ struct ResultView: View {
         }
         .navigationTitle("요약")
         .navigationBarBackButtonHidden()
+        .onDisappear {
+            workoutManager.isSaved = false
+            workoutManager.resetWorkout()
+        }
     }
 }
 
@@ -235,10 +240,10 @@ struct HealthKitView: View {
             .cornerRadius(40)
         }
         .padding(.horizontal, 5)
-        .onDisappear {
-            workoutManager.isSaved = false
-            workoutManager.resetWorkout()
-        }
+//        .onDisappear {
+//            workoutManager.isSaved = false
+//            workoutManager.resetWorkout()
+//        }
     }
 
 }


### PR DESCRIPTION
## 🎾 PR 요약

🌱 작업한 브랜치
- feature/#152

## ✏️ 작업한 내용
- 10초 이상 운동 했을 때 ResultView의 운동 결과 탭에서 다른 탭 갔다 오면 10초 미만 결과 화면으로 바뀌어있는 문제 해결

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 🎬 스크린샷


## 📮 관련 이슈
- Resolved: #152

