### PR TITLE
[Fix] 운동 결과 데이터 중복 저장 문제 해결 및 watchOS 최적화 작업 #159, #161

### DIFF
--- a/MC3_Tering/MC3_Tering/View/MainView/MainView.swift
+++ b/MC3_Tering/MC3_Tering/View/MainView/MainView.swift
@@ -35,6 +35,25 @@ struct MainView: View {
                 VStack(spacing: 0) {
                     tabsContainer()
                     tabViewContainer()
+                    
+                    // TODO: - 데이터 확인용 코드 (나중에 삭제하기)
+//                    /// 데이터 잘 들어가고 있는지 확인
+//                    Button {
+//                        if self.model.session.isReachable {
+//                            self.reachable = "Yes"
+//                        }
+//                        else {
+//                            self.reachable = "No"
+//                        }
+//                    } label: {
+//                        Text("Update")
+//                    }
+//
+//                    //밑에 처럼 그냥 불러오기만 하면 됨
+//                    Text("receive from watch backhandperfect: \(workoutDataModel.backhandPerfect)")
+//                    Text("receive from watch total swing count: \(workoutDataModel.totalSwingCount)")
+//                    Text("receive from watch date: \(model.workOutDate ?? Date())")
+//                    Text("receive from watch total swing: \(model.totalSwingCount)")
                 }
                 .padding(.top, 20)
             }
@@ -192,11 +211,12 @@ extension MainView {
             .scrollIndicators(.hidden)
             
             ScrollView {
-                Button(action: {
-                    workoutDataModel.testCreate100Days()
-                }, label: {
-                    Text("workout 시험데이터 100개 생성")
-                })
+                // 시험 데이터 확인용 버튼
+//                Button(action: {
+//                    workoutDataModel.testCreate100Days()
+//                }, label: {
+//                    Text("workout 시험데이터 100개 생성")
+//                })
                 RecordListView(workoutDataModel: workoutDataModel, months: months)
                     .padding(.top, 2)
                     .padding(.horizontal, 16)

--- a/MC3_Tering/MC3_Tering_Watch Watch App/MC3_Tering_WatchApp.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/MC3_Tering_WatchApp.swift
@@ -12,6 +12,7 @@ struct MC3_Tering_Watch_Watch_AppApp: App {
     @StateObject var workoutResultInfo = WorkoutResultInfo()
     @StateObject var swingInfo = SwingInfo()
     @StateObject var workoutManager = WorkoutManager()
+    @StateObject var viewModelWatch = ViewModelWatch()
     
     var body: some Scene {
         WindowGroup {
@@ -19,6 +20,7 @@ struct MC3_Tering_Watch_Watch_AppApp: App {
                 .environmentObject(workoutResultInfo)
                 .environmentObject(swingInfo)
                 .environmentObject(workoutManager)
+                .environmentObject(viewModelWatch)
         }
     }
 }

--- a/MC3_Tering/MC3_Tering_Watch Watch App/Model/Workout/WorkoutManager.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/Model/Workout/WorkoutManager.swift
@@ -141,6 +141,7 @@ class WorkoutManager: NSObject, ObservableObject {
         activeEnergy = 0
         averageHeartRate = 0
         heartRate = 0
+        isSaved = false
     }
 }
 

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
@@ -168,7 +168,7 @@ struct HealthKitView: View {
     }()
     
     @EnvironmentObject var workoutResultInfo: WorkoutResultInfo
-    @ObservedObject var model = ViewModelWatch()
+    @EnvironmentObject var viewModelWatch: ViewModelWatch
     @EnvironmentObject var swingInfo: SwingInfo
     
     @State private var isFirstAppear = false
@@ -252,7 +252,7 @@ struct ResultView_Previews: PreviewProvider {
 
 extension HealthKitView {
     private func sendSwingDataToPhone() {
-        self.model.session.transferUserInfo([
+        self.viewModelWatch.session.transferUserInfo([
             "totalSwingCount" : self.swingInfo.totalSwingCount,
             "forehandPerfect" : self.swingInfo.forehandPerfect,
             "totalForehandCount" : self.swingInfo.totalForehandCount,

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/ResultView/ResultView.swift
@@ -48,7 +48,6 @@ struct ResultView: View {
         .navigationTitle("요약")
         .navigationBarBackButtonHidden()
         .onDisappear {
-            workoutManager.isSaved = false
             workoutManager.resetWorkout()
         }
     }
@@ -172,6 +171,8 @@ struct HealthKitView: View {
     @ObservedObject var model = ViewModelWatch()
     @EnvironmentObject var swingInfo: SwingInfo
     
+    @State private var isFirstAppear = false
+    
     var body: some View {
         VStack {
             if workoutManager.isSaved == false {
@@ -212,13 +213,17 @@ struct HealthKitView: View {
                         Spacer()
                     }
                     .onAppear {
-                        print("===============================결과 확인===================================")
-                        print("저장된 평균 심박수 : \(workoutResultInfo.averageHeartRate)")
-                        print("저장된 소모 칼로리 : \(workoutResultInfo.burningCal)")
-                        print("저장된 운동 시간 : \(workoutResultInfo.workOutTime)")
-                        print("저장된 운동일 : \(workoutResultInfo.workOutDate)")
-                        print("======================================================================")
-                        sendSwingDataToPhone()
+                        if !isFirstAppear {
+                            print("===============================결과 확인===================================")
+                            print("저장된 평균 심박수 : \(workoutResultInfo.averageHeartRate)")
+                            print("저장된 소모 칼로리 : \(workoutResultInfo.burningCal)")
+                            print("저장된 운동 시간 : \(workoutResultInfo.workOutTime)")
+                            print("저장된 운동일 : \(workoutResultInfo.workOutDate)")
+                            print("======================================================================")
+                            sendSwingDataToPhone()
+                            
+                            isFirstAppear = true
+                        }
                     }
                 }
             }

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/CountingView.swift
@@ -51,7 +51,7 @@ struct QuitView: View {
     
     @State var showResultView = false
     
-    @ObservedObject var model = ViewModelWatch()
+    @EnvironmentObject var viewModelWatch: ViewModelWatch
     @EnvironmentObject var swingInfo: SwingInfo
     
     @State private var workoutTimeFormatter: DateComponentsFormatter = { // 운동 시간 formatter


### PR DESCRIPTION
## 🎾 PR 요약

🌱 작업한 브랜치
- rei/feat/#159
- rei/feat/#161

## ✏️ 작업한 내용
- 운동 결과 중복 저장되는 문제 해결
- watchOS 최적화 작업

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 운동 결과 중복 저장 문제
- 워치의 ResultView에서 다른 탭으로 이동하고 HealthKit 뷰로 돌아올 때마다 운동 데이터가 중복 저장되는 문제
<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/150530d3-f590-4186-a922-97994bcbd4d9" width="300" alt="버그 캡쳐 사진">

👉 HealthKitView의 .onAppear에서 최초 1회에만 iOS로 결과 전송하도록 isFirstAppear 변수를 추가해줌
<img width="500" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/7e25bd97-43ca-41e1-9ceb-5053eebbdaba">

### watchOS 최적화 작업
- QuitView(CountingView.swift)와 HealthKitView(ResultView.swift)에서 ViewModelWatch 인스턴스를 새로 만들어줘서 세션 연결 확인이 불필요하게 반복됨
  - [WC] already in progress or activated 라는 메세지가 계속 뜸
👉 루트 뷰에서 최초 1회만 인스턴스를 생성해주고 @EnvironmentObject로 사용하도록 수정
<img width="432" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/dd3a7dff-a1a3-4184-b162-a1cf064ec698">


## 🎬 스크린샷


## 📮 관련 이슈
- Resolved: #159
- Resolved: #161

