### PR TITLE
[Fix] watchOS 스윙 분류 중 다른 스윙 쌓이는 문제 해결 #165

### DIFF
--- a/MC3_Tering/MC3_Tering_Watch Watch App/Model/Workout/WorkoutManager.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/Model/Workout/WorkoutManager.swift
@@ -9,6 +9,7 @@ import Foundation
 import HealthKit
 import SwiftUI
 
+// MARK: - Workout 세션 관련 동작을 처리하는 클래스
 class WorkoutManager: NSObject, ObservableObject {
     @StateObject var tennisClassifierViewModel = TennisClassifierViewModel.shared
     

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/Measurement/MeasuringView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/Measurement/MeasuringView.swift
@@ -14,6 +14,7 @@ struct MeasuringView: View {
     @State private var bounceHeight: BounceHeight? = nil
     
     @EnvironmentObject var swingInfo: SwingInfo
+    @StateObject var tennisClassifierViewModel = TennisClassifierViewModel.shared
     
     func bounceAnimation() {
         
@@ -72,6 +73,7 @@ struct MeasuringView: View {
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 self.isSwingResultViewPresented = true
+                tennisClassifierViewModel.pauseMotionTracking() // 측정 중에는 device motion 추적 일시중지
             }
         }
         .background(

--- a/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/Measurement/SwingResultView.swift
+++ b/MC3_Tering/MC3_Tering_Watch Watch App/View/WorkoutView/Measurement/SwingResultView.swift
@@ -45,6 +45,9 @@ struct SwingResultView: View {
             getSwingColor()
             swingCompleteView()
         }
+        .onDisappear {
+            tennisClassifierViewModel.startMotionTracking() // 측정 결과 확인이 끝나면 device motion 추적 다시 시작
+        }
         .background(
             NavigationLink(destination: CountingView(), isActive: $isSwingCountViewPresented) {
                 EmptyView()


### PR DESCRIPTION
## 🎾 PR 요약

🌱 작업한 브랜치
- rei/feat/#165

## ✏️ 작업한 내용
### TennisClassifierViewModel.swift 메서드 수정
- Device Motion 추적을 일시중지하는 메서드 추가 ( pauseMotionTracking() )
<img width="634" alt="DeviceMotionPause" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/87cc5adc-c017-4224-9870-c36533f5f71d">

- 모델 불러오는 코드를 startMotionTracking() 메서드에서 init()으로 옮겨줌
  - ‼️인스턴스 초기화 시 최초 1회에만(싱글톤 패턴) 모델을 불러오도록 수정하면서 불필요하게 모델을 불러오던 과정을 없앰
<img width="1279" alt="모델불러오기" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/beb69826-31bc-422a-b308-56b4b0ac947c">

### MeasuringView.swift, SwingResultView.swift에 Device Motion 추적 일시중지, 재개 메서드 호출부 추가
- 일시중지
<img width="1143" alt="MeasuringView" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/26ac4a72-4f9b-4509-95f3-7460eb3919d1">

- 재개
<img width="1162" alt="SwingResultView" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/5700dc2f-6c0c-440d-9b2d-5426e6436efc">



## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- ⚠️ Device Motion 추적을 재개할 때 버퍼에 센서값이 쌓이는 시간으로 인한 지연이 체감되는지 확인 필요

## 🎬 스크린샷


## 📮 관련 이슈
- Resolved: #165

