### PR TITLE
[Fix] 온보딩 화면 레이아웃 밀리는 문제 해결 #170

### DIFF
--- a/MC3_Tering/MC3_Tering/View/OnboardingView/OnboardingView.swift
+++ b/MC3_Tering/MC3_Tering/View/OnboardingView/OnboardingView.swift
@@ -74,6 +74,13 @@ struct OnboardingView: View {
             }
             .padding(.horizontal, 18)
         }
+        // 키보드 올라왔을 때 safeArea 침범하는 현상 방지
+        .padding(.top, UIApplication
+            .shared
+            .connectedScenes
+            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+            .first { $0.isKeyWindow }?.safeAreaInsets.top
+        )
         .onTapGesture {
             isKeyboardOn = false
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
@@ -103,7 +110,9 @@ extension OnboardingView {
                 HStack(spacing: 0) {
                     if pageNumber != 0 {
                         Button(action: {
-                            onboardingPage -= 1
+                            if onboardingPage > 0 {
+                                onboardingPage -= 1
+                            }
                         }) {
                             Image(systemName: "chevron.left")
                                 .resizable()

--- a/MC3_Tering/MC3_Tering/View/OnboardingView/OnboardingView.swift
+++ b/MC3_Tering/MC3_Tering/View/OnboardingView/OnboardingView.swift
@@ -75,11 +75,11 @@ struct OnboardingView: View {
             .padding(.horizontal, 18)
         }
         // 키보드 올라왔을 때 safeArea 침범하는 현상 방지
-        .padding(.top, UIApplication
+        .padding(.top, isKeyboardOn ? UIApplication
             .shared
             .connectedScenes
             .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-            .first { $0.isKeyWindow }?.safeAreaInsets.top
+            .first { $0.isKeyWindow }?.safeAreaInsets.top : 0
         )
         .onTapGesture {
             isKeyboardOn = false
@@ -113,6 +113,7 @@ extension OnboardingView {
                             if onboardingPage > 0 {
                                 onboardingPage -= 1
                             }
+                            isKeyboardOn = false
                         }) {
                             Image(systemName: "chevron.left")
                                 .resizable()
@@ -125,7 +126,8 @@ extension OnboardingView {
                 }
                 .padding(.leading, 18)
             }
-            .padding(.bottom, 78)
+            .padding(.top, 10)
+            .padding(.bottom, isKeyboardOn ? 10 : 78)
             VStack(spacing: 0) {
                 HStack(spacing: 0) {
                     Text(boldString)
@@ -191,7 +193,8 @@ extension OnboardingView {
             }
         }
         .disabled(!isNicknameInput)
-        .padding(.bottom, isKeyboardOn ? 10 : 90)
+        .padding(.bottom, 90)
+//        .padding(.bottom, isKeyboardOn ? 40 : 90)
     }
     
     private func profileContainer() -> some View {


### PR DESCRIPTION
## 🎾 PR 요약

🌱 작업한 브랜치
- rei/feat/#170

## ✏️ 작업한 내용
### ‼️온보딩 화면에서 닉네임 입력 시 키보드가 올라오면서 상단 safeArea를 침범하는 문제

- OnboardingView.swift
<img width="300" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/c26ebe01-824c-46bb-92dc-70e2c36c1d98">


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 🎬 스크린샷
- 수정 전
<img width="250" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/42255195-779c-45fc-a79c-4c3e44cfec55">

- 수정 후
<img width="250" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/19724de9-ac07-4dc6-bfdf-99138089dbdd">


## 📮 관련 이슈
- Resolved: #170

