### PR TITLE
[Design] 작은 기기 사이즈 레이아웃 대응 코드 추가 #170

### DIFF
--- a/MC3_Tering/MC3_Tering/View/OnboardingView/OnboardingView.swift
+++ b/MC3_Tering/MC3_Tering/View/OnboardingView/OnboardingView.swift
@@ -31,6 +31,8 @@ struct OnboardingView: View {
     @State private var profileImage: Data?
     @State private var isKeyboardOn = false
     
+    let isSmallDevice: Bool = UIScreen.main.bounds.height <= 736.0
+    
     var body: some View {
         ZStack {
             if onboardingPage == 0 {
@@ -73,6 +75,9 @@ struct OnboardingView: View {
                 
             }
             .padding(.horizontal, 18)
+        }
+        .onAppear {
+            print("높이: \(UIScreen.main.bounds.height)")
         }
         // 키보드 올라왔을 때 safeArea 침범하는 현상 방지
         .padding(.top, isKeyboardOn ? UIApplication
@@ -126,7 +131,8 @@ extension OnboardingView {
                 }
                 .padding(.leading, 18)
             }
-            .padding(.top, 10)
+            .padding(.top, isSmallDevice ? (isKeyboardOn ? 80 : 10) : 0)
+//            .padding(.top, isKeyboardOn ? 80 : 10)
             .padding(.bottom, isKeyboardOn ? 10 : 78)
             VStack(spacing: 0) {
                 HStack(spacing: 0) {


### PR DESCRIPTION
## 🎾 PR 요약

🌱 작업한 브랜치
- rei/feat/#170

## ✏️ 작업한 내용
- 작은 기기 사이즈 레이아웃 대응하도록 수정
  - iPhone 8
  - iPhone 8 Plus
  - iPhone SE (3rd generation)
  - 등

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 기기 Height 크기를 보고 특정 값 이하일 때만 레이아웃 조정 코드 동작하도록 수정
<img width="600" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team9-F4/assets/89764127/7b200d2d-7b75-4d52-9475-d818f3c06500">


## 🎬 스크린샷


## 📮 관련 이슈
- Resolved: #170

